### PR TITLE
Add support for installation via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "tv4",
+  "version": "1.0.3",
+  "main": "tv4.js",
+  "ignore": [
+    "**/.*",
+    "*.php",
+    "*.html",
+    "*.min.js",
+    "*.txt",
+    "*.md",
+    "package.json",
+    "node_modules",
+    "tests",
+    "source"
+  ]
+}


### PR DESCRIPTION
`tv4` is already available for installation via `bower install tv4`, however, as it does not include a `bower.json` it installs a lot more than you actually need in the frontend.

[![bower-logo](https://f.cloud.github.com/assets/9906/590610/461c6506-c9e8-11e2-96ab-720a0f5b07a9.png)](http://bower.io)
