### PR TITLE
add component.json to allow component install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ npm-debug.log
 .DS_Store
 
 /*.tgz
+
+build
+components
+

--- a/component.js
+++ b/component.js
@@ -1,0 +1,3 @@
+
+module.exports = require('./tv4').tv4;
+

--- a/component.json
+++ b/component.json
@@ -1,0 +1,15 @@
+{
+  "name": "tv4",
+  "repo": "geraintluff/tv4",
+  "description": "Tiny Validator for JSON Schema v4",
+  "version": "1.0.7",
+  "keywords": [],
+  "dependencies": {},
+  "development": {},
+  "license": "MIT",
+  "main": "component.js",
+  "scripts": [
+    "component.js",
+    "tv4.js"
+  ]
+}

--- a/test/index-component.html
+++ b/test/index-component.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>tv4</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="stylesheet" href="./deps/mocha.css"/>
+    <script src="./deps/jquery.js"></script>
+    <script src="./deps/mocha.js"></script>
+    <script src="./deps/proclaim.js"></script>
+    <script src="../build/build.js"></script>
+    <script>
+        var tv4 = require('tv4');
+
+        //save globals so tests can be shared between node an browsers
+        window.refs = {tv4:tv4, assert:proclaim};
+        mocha.setup('bdd');
+        window.onload = function () {
+            if (navigator.userAgent.indexOf('PhantomJS') < 0) {
+                mocha.run();
+            }
+        };
+    </script>
+    <script src="./all_concat.js"></script>
+</head>
+<body>
+<div id="mocha"></div>
+</body>
+</html>


### PR DESCRIPTION
[Component](https://github.com/component/component) needs a component.json in order to install/build, this PR adds it.

Also added a tiny shim (component.js) so you can simply `require('tv4')` instead of `require('tv4').tv4` from within component.

And I added a component-ized version of the browser tests (`test/index-component.html`).
