### PR TITLE
Clarify `format` support in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ tv4.language('fr')
 
 ##### addFormat(format, validationFunction)
 
-Add a custom format validator.
+Add a custom format validator. (There are no built-in format validators.)
 
 * `format` is a string, corresponding to the `"format"` value in schemas.
 * `validationFunction` is a function that either returns:


### PR DESCRIPTION
The documentation was worded in such a way that I inferred built-in format validators (specifically, those listed in the JSON-Schema spec). Just added a bit of clarification to the readme to explicitly state that there are no format validators built-in.
