### PR TITLE
Fix typo in addSchema

### DIFF
--- a/tv4.js
+++ b/tv4.js
@@ -294,7 +294,7 @@ ValidatorContext.prototype.addSchema = function (url, schema) {
 			return;
 		}
 	}
-	if (url = getDocumentUri(url) + "#") {
+	if (url === getDocumentUri(url) + "#") {
 		// Remove empty fragment
 		url = getDocumentUri(url);
 	}


### PR DESCRIPTION
Looks like this = should be an === to check if there is an empty fragment
