### PR TITLE
Allow validation of dictionary-like structures when "items" is used in conjunction with the type "object"

### DIFF
--- a/test/tests/05 - Objects/07 - items.js
+++ b/test/tests/05 - Objects/07 - items.js
@@ -1,0 +1,24 @@
+describe("Objects 07", function () {
+
+	it("dictionary items success", function () {
+		var data = {"1":1, "2":2, "3":3, "4":4};
+		var schema = {
+			"items": {
+				"type": "integer"
+			}
+		};
+		var valid = tv4.validate(data, schema);
+		assert.isTrue(valid);
+	});
+
+	it("dictionary items failure", function () {
+		var data = {"1":1, "2":2, "3":true, "4":4};
+		var schema = {
+			"items": {
+				"type": "integer"
+			}
+		};
+		var valid = tv4.validate(data, schema);
+		assert.isFalse(valid);
+	});
+});

--- a/tv4.js
+++ b/tv4.js
@@ -855,7 +855,6 @@ ValidatorContext.prototype.validateObjectItems = function validateArrayItems(dat
 	}
 	var error, k;
 	for (var k in data) {
-		console.log('validating', data[k]);
 		if (error = this.validateAll(data[k], schema.items, [k], ["items"], dataPointerPath + "/" + k)) {
 			return error;
 		}		

--- a/tv4.js
+++ b/tv4.js
@@ -723,6 +723,7 @@ ValidatorContext.prototype.validateObject = function validateObject(data, schema
 		|| this.validateObjectRequiredProperties(data, schema, dataPointerPath)
 		|| this.validateObjectProperties(data, schema, dataPointerPath)
 		|| this.validateObjectDependencies(data, schema, dataPointerPath)
+		|| this.validateObjectItems(data, schema, dataPointerPath)
 		|| null;
 };
 
@@ -844,6 +845,20 @@ ValidatorContext.prototype.validateObjectDependencies = function validateObjectD
 				}
 			}
 		}
+	}
+	return null;
+};
+
+ValidatorContext.prototype.validateObjectItems = function validateArrayItems(data, schema, dataPointerPath) {
+	if (schema.items === undefined) {
+		return null;
+	}
+	var error, k;
+	for (var k in data) {
+		console.log('validating', data[k]);
+		if (error = this.validateAll(data[k], schema.items, [k], ["items"], dataPointerPath + "/" + k)) {
+			return error;
+		}		
 	}
 	return null;
 };


### PR DESCRIPTION
I added this to allow lookups through the validator when they have a consistent schema in their items, I've found it quite useful, though I don't know if this unacceptably breaks the json schema specification.