### PR TITLE
added `result.toString()`

### DIFF
--- a/tv4.js
+++ b/tv4.js
@@ -1523,6 +1523,15 @@ function createApi(language) {
 			this.error = error;
 			this.missing = context.missing;
 			this.valid = (error === null);
+
+			this.toString = function () {
+				if (this.error) {
+					return this.error.message;
+				} else {
+					return 'Object passed schema validation';
+				}
+			};
+
 			return this.valid;
 		},
 		validateResult: function () {


### PR DESCRIPTION
Hey there,

 I was running into trouble getting useful information automatically from failed schema validations. Not all systems can dump the object, and it's nice to have a string explaining the error (without having to know about the object structure). So I added result.toString() so when schema validation fails, displaying the error in a string shows the error message instead of `[object Object]`.
