### PR TITLE
Handle undefined properties

### DIFF
--- a/source/object.js
+++ b/source/object.js
@@ -51,6 +51,9 @@ ValidatorContext.prototype.validateObjectProperties = function validateObjectPro
 	for (var key in data) {
 		var keyPointerPath = dataPointerPath + "/" + key.replace(/~/g, '~0').replace(/\//g, '~1');
 		var foundMatch = false;
+		if (data[key] === undefined && (!schema.required || schema.required.indexOf(key) < 0)) {
+			continue;
+		}
 		if (schema.properties !== undefined && schema.properties[key] !== undefined) {
 			foundMatch = true;
 			if (error = this.validateAll(data[key], schema.properties[key], [key], ["properties", key], keyPointerPath)) {

--- a/test/tests/05 - Objects/07 - undefined.js
+++ b/test/tests/05 - Objects/07 - undefined.js
@@ -1,0 +1,24 @@
+describe("Objects 07", function() {
+    it("validate an optional undefined property", function () {
+        var data = {optional: undefined};
+        var schema = {
+            properties: {
+                optional: {"type": "string"},
+            }
+        };
+        var valid = tv4.validate(data, schema);
+        assert.isTrue(valid);
+    });
+
+    it("does not validate a undefined required property", function () {
+        var data = {required: undefined};
+        var schema = {
+            properties: {
+                required: {"type": "string"}
+            },
+            required: ['required']
+        };
+        var valid = tv4.validate(data, schema);
+        assert.isFalse(valid);
+    });
+});


### PR DESCRIPTION
This pull-request allow to validate objects with properties set to `undefined` if the properties are not required.

It seems coherent with this:

``` javascript
JSON.stringify({nullProp: null, undefinedProp: undefined})
>> {"nullProp":null}"
```

So with this  schema:

``` javascript
var schema = {
    properties: {
        key: {type: 'string'}
    }
};
```

 we should have:

``` javascript
tv4.validate({key: undefined}, schema);
>> true
tv4.validate({key: null}, schema);
>> false
```
