### PR TITLE
Renamed Norwegian (Bokmål) translation to ISO 639-1 code 'nb'

### DIFF
--- a/lang/nb.js
+++ b/lang/nb.js
@@ -40,16 +40,17 @@
 	if (typeof define === 'function' && define.amd) {
 		// AMD. Register as an anonymous module.
 		define(['../tv4'], function(tv4) {
-			tv4.addLanguage('no-nb', lang);
+			tv4.addLanguage('nb', lang);
 			return tv4;
 		});
 	} else if (typeof module !== 'undefined' && module.exports) {
 		// CommonJS. Define export.
 		var tv4 = require('../tv4');
-		tv4.addLanguage('no-nb', lang);
+		tv4.addLanguage('nb', lang);
 		module.exports = tv4;
 	} else {
 		// Browser globals
-		global.tv4.addLanguage('no-nb', lang);
+		global.tv4.addLanguage('nb', lang);
 	}
 })(this);
+


### PR DESCRIPTION
**no-nb** follows no standarised scheme for language codes, and has thus been renamed to the *ISO 639-1* compliant language code **nb**. If the *RFC 5646*-scheme is preferred, **nb-NO** is acceptable, though unnecessary for the Norwegian language which has no variants based on country.