### PR TITLE
Allow undefined attributes

### DIFF
--- a/source/basic.js
+++ b/source/basic.js
@@ -1,5 +1,7 @@
 ValidatorContext.prototype.validateBasic = function validateBasic(data, schema, dataPointerPath) {
-        if (data === undefined) return null;
+        if (data === undefined) {
+        	return null;
+        }
 	var error;
 	if (error = this.validateType(data, schema, dataPointerPath)) {
 		return error.prefixWith(null, "type");

--- a/source/basic.js
+++ b/source/basic.js
@@ -1,4 +1,5 @@
 ValidatorContext.prototype.validateBasic = function validateBasic(data, schema, dataPointerPath) {
+        if (data === undefined) return null;
 	var error;
 	if (error = this.validateType(data, schema, dataPointerPath)) {
 		return error.prefixWith(null, "type");


### PR DESCRIPTION
Undefined attributes are often treated as being non existent. Therefore an undefined attribute passes validation.