### PR TITLE
Do not resolve local refs.

### DIFF
--- a/test/tests/07 - $ref/04 - ref.js
+++ b/test/tests/07 - $ref/04 - ref.js
@@ -37,4 +37,37 @@ describe("$ref 04", function () {
 
 		//this.assert(tv4.missing.length == 0, "should have no missing schemas");
 	});
+
+		it("internal $ref unreachable schema uri", function () {
+		var schema = {
+			"id": "https://not-connected-to-the-internet.com/schema.json#",
+			"$schema": "https://not-connected-to-the-internet/v1/schema#",
+			"title": "This is a schema",
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"refd": {
+					"$ref": '#/definitions/refd'
+				}
+			}, "definitions": {
+				"refd": {
+					"additionalProperties": false,
+					"type": "object",
+					"required": ["value"],
+					"properties": {
+						"value": {
+							"type": "string"
+						}
+					}
+				}
+			}
+		};
+		var invalid = { refd: { value: 1 } };
+		var valid = { refd: { value: "string" } };
+
+		assert.isTrue(!tv4.validate(invalid, schema), "Should not validate");
+		assert.isTrue(tv4.validate(valid, schema), "Should valid");
+
+		assert.length(tv4.missing, 0, "should have no missing schemas");
+	});
 });

--- a/tv4.js
+++ b/tv4.js
@@ -1336,7 +1336,8 @@ function normSchema(schema, baseUri) {
 				normSchema(schema[i], baseUri);
 			}
 		} else {
-			if (typeof schema['$ref'] === "string") {
+			// If the #ref is local, don't resolve full URI
+			if (typeof schema['$ref'] === "string" && schema['$ref'].charAt(0) !== '#') {
 				schema['$ref'] = resolveUrl(baseUri, schema['$ref']);
 			}
 			for (var key in schema) {


### PR DESCRIPTION
I ran into a problem when validating with the schema listed below. It seems that when resolving the local `$ref`, tv4 is building up a full URI for the schema rather than looking it up locally.

This PR makes a small change(I think) to the normlize schema path. It fixes my problem, but who knows what else I might have broken... please let me know if I'm off in the weeds here. It seemed that there were a number of ways to fix the problem, but this was the least intrusive.

`````
{
	"id": "https://not-connected-to-the-internet.com/schema.json#",
	"$schema": "https://not-connected-to-the-internet/v1/schema#",
	"title": "This is a schema",
	"type": "object",
	"additionalProperties": false,
	"properties": {
		"refd": {
			"$ref": "#/definitions/refd"
		}
	}, "definitions": {
		"refd": {
			"additionalProperties": false,
			"type": "object",
			"required": ["value"],
			"properties": {
				"value": {
					"type": "string"
				}
			}
		}
	}
};
````
