### PR TITLE
Skipped format validation for allowed null values.

### DIFF
--- a/source/validate.js
+++ b/source/validate.js
@@ -316,6 +316,15 @@ ValidatorContext.prototype.validateAll = function (data, schema, dataPathParts, 
 	return this.handleError(error);
 };
 ValidatorContext.prototype.validateFormat = function (data, schema) {
+	var allowedTypes = schema.type;
+	if (!Array.isArray(allowedTypes)) {
+		allowedTypes = [allowedTypes];
+	}
+
+	if (data === null && allowedTypes.indexOf('null') !== -1) {
+		return null;
+	}
+
 	if (typeof schema.format !== 'string' || !this.formatValidators[schema.format]) {
 		return null;
 	}

--- a/test/tests/11 - format/01 - register validator.js
+++ b/test/tests/11 - format/01 - register validator.js
@@ -58,4 +58,19 @@ describe("Registering custom validator", function () {
 		assert.isFalse(result2.valid);
 		assert.includes(result2.error.message, 'break 2');
 	});
+
+	it("Custom validator should be skipped for null values", function () {
+		tv4.addFormat('null-format', function (data) {
+			if (data !== "test") {
+				return "string does not match";
+			}
+		});
+
+		var schema = {type: ["string", "null"], format: 'null-format'};
+		var data1 = "test";
+		var data2 = null;
+
+		assert.isTrue(tv4.validate(data1, schema));
+		assert.isTrue(tv4.validate(data2, schema));
+	});
 });


### PR DESCRIPTION
Allowed null data should not be passed into format validators. 

For example, following data:  

`
{value:null}
`

should not fail if null is allowed in schema: 

`
{"value":
{"type": ["string", "null"]}
}
`