### PR TITLE
TV4: Remove PhantomJS Dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,6 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-concat-sourcemap');
 	grunt.loadNpmTasks('grunt-mocha-test');
 	grunt.loadNpmTasks('grunt-markdown');
-	grunt.loadNpmTasks('grunt-mocha');
 	grunt.loadNpmTasks('grunt-component-io');
 	grunt.loadNpmTasks('grunt-push-release');
 	grunt.loadNpmTasks('grunt-regex-replace');

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-jshint": "~0.6.2",
     "mocha": "~1.11.0",
-    "grunt-mocha": "~0.4",
     "grunt-mocha-test": "~0.5.0",
     "grunt-cli": "~0.1.9",
     "grunt-contrib-uglify": "~0.2.2",


### PR DESCRIPTION
Phantomjs is an unmaintained project. Removed grunt-mocha from dev-dependencies as it uses phantomjs internally. Removed grunt-mocha dependency from Gruntfile.js.

Signed-off-by: ossdev <ossdev@puresoftware.com>