### PR TITLE
fix: fixing the remainder for the validateMultipleOf function for the…

### DIFF
--- a/tv4.js
+++ b/tv4.js
@@ -779,7 +779,7 @@ ValidatorContext.prototype.validateMultipleOf = function validateMultipleOf(data
 		return null;
 	}
 	if (typeof data === "number") {
-		var remainder = (data/multipleOf)%1;
+		var remainder = Math.abs((data/multipleOf)%1);
 		if (remainder >= CLOSE_ENOUGH_LOW && remainder < CLOSE_ENOUGH_HIGH) {
 			return this.createError(ErrorCodes.NUMBER_MULTIPLE_OF, {value: data, multipleOf: multipleOf}, '', '', null, data, schema);
 		}


### PR DESCRIPTION
The validateMultipleOf function fails for negative numbers since the remainder changes sign and this no longer fits in the [CLOSE_ENOUGH_LOW, CLOSE_ENOUGH_HIGH] interval as explained in https://github.com/geraintluff/tv4/issues/281

The fix uses the absolute value as remainder to avoid sign changes.